### PR TITLE
Incorrect Attributes being returned.

### DIFF
--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -65,7 +65,8 @@ public class RedissonSession extends StandardSession {
     private final ReadMode readMode;
     private final UpdateMode updateMode;
 
-    private final AtomicInteger usages = new AtomicInteger();
+    // Initialize to one, since upon creation there is one usage
+    private final AtomicInteger usages = new AtomicInteger(1);
     private Map<String, Object> loadedAttributes = Collections.emptyMap();
     private Set<String> removedAttributes = Collections.emptySet();
 

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -373,9 +373,10 @@ public class RedissonSession extends StandardSession {
         if (broadcastSessionEvents) {
             newMap.put(IS_EXPIRATION_LOCKED, isExpirationLocked);
         }
-        
-        if (attrs != null) {
-            for (Entry<String, Object> entry : attrs.entrySet()) {
+
+        Map<String,Object> attrMap = readMode == ReadMode.REDIS ? loadedAttributes : attrs;
+        if (attrMap != null) {
+            for (Entry<String, Object> entry : attrMap.entrySet()) {
                 newMap.put(entry.getKey(), entry.getValue());
             }
         }

--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSessionManager.java
@@ -67,7 +67,9 @@ public class RedissonSessionManager extends ManagerBase {
 
     private final String nodeId = UUID.randomUUID().toString();
 
-    private static ValveBase updateValve;
+    // For the test, by placing this in a static there is only 1 update valve, and its registered to the first
+    // Tomcat instance, so that server2 never triggers the update valve, as they both have their own Engine/pipeline instances
+    private ValveBase updateValve;
 
     private static Set<String> contextInUse = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 

--- a/redisson-tomcat/redisson-tomcat-8/src/test/java/org/redisson/tomcat/RedissonSessionManagerTest.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/test/java/org/redisson/tomcat/RedissonSessionManagerTest.java
@@ -156,6 +156,9 @@ public class RedissonSessionManagerTest {
             // Trigger a read on the first server, it will pull the latest value from redis for "test", and be returned correctly
             // HOWEVER, it will trigger a session.save() from the UpdateValve, which will write back everything in
             // the local attr map back to redis, including the stale value of "test"
+
+            // with READ_MODE REDIS, and not AFTER_REQUEST, this will fail due to the new UsageValve not calling session.endUsage()
+            // on the first request which creates a sessions. This leaves around a stale loadedAttributes map
             read(executor, "test", "from_server2");
             // This should have the result of from_server2, but because server1 in the previous call wrote back its stale in memory value
             // due to the session.save() call, it has the incorrect value now.


### PR DESCRIPTION
### Scenario 1
Expected behavior:
**Given**: UpdateMode=AFTER_REQUEST and ReadMode=REDIS
When two tomcat instances are writing to the same redis server for the same session, we expect the last write done by either server to be persisted, and read by subsequent reads

Actual Behavior:
When AFTER_REQUEST is set, stale attribute values are being written back to the redis server, even if more recent values have been read or persisted to redis.

See commit: https://github.com/ghollies/redisson/pull/1/commits/637f877fb20eef46eea2afa97bc286fd000426e8
**Test Case for stale session values - AFTER_REQEUST**
* Created a new test cases highlighting bug where if two servers have
  loaded a value into the session from redis, and the updateMode=
  AFTER_REQUEST, stale in memory data can be written back out to redis

### Scenario 2
Expected behavior:
**Given**: UpdateMode=DEFAULT and ReadMode=REDIS
When two tomcat instances are writing to the same redis server for the same session, we expect the last write done by either server to be persisted, and read by subsequent reads

Actual Behavior:
When the second request goes to the first server, it will use its potentially stale in memory session values rather than reading it from redis, due to loadedAttribtues not being cleared at the end of the first call

See commit: https://github.com/ghollies/redisson/pull/1/commits/1188bb5247fbb6cdf83681ea3ec734233073095c
**loadedAtrributes not cleared after first request**
* The newly introduced loadedAttributes map, and UsageValve do not
  always clear after each request. The first time a session is created,
  it is not marked with startUsage, and endUsage is never called
  which leaves the loadedAttribtues map in place until the end of the
  next request.
