### PR TITLE
Update getAttributeNames for loadedAttributes

### DIFF
--- a/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
+++ b/redisson-tomcat/redisson-tomcat-8/src/main/java/org/redisson/tomcat/RedissonSession.java
@@ -143,7 +143,11 @@ public class RedissonSession extends StandardSession {
                 throw new IllegalStateException
                     (sm.getString("standardSession.getAttributeNames.ise"));
             }
-            return Collections.enumeration(map.readAllKeySet());
+            Set<String> attributeKeys = new HashSet<>();
+            attributeKeys.addAll(map.readAllKeySet());
+            attributeKeys.addAll(loadedAttributes.keySet());
+            attributeKeys.removeAll(removedAttributes);
+            return Collections.enumeration(attributeKeys);
         }
         
         return super.getAttributeNames();


### PR DESCRIPTION
* Include handling for loaded and removed attributes when requesting
  all attribute names to be as current as possible, rather than always
  delegating to the remote map in READ_MODE = REDIS